### PR TITLE
Simplify test to pass in python 3

### DIFF
--- a/openprovider/tests/test_integration.py
+++ b/openprovider/tests/test_integration.py
@@ -42,7 +42,7 @@ class TestExtensions(tests.ApiTestCase):
     def test_search_extension(self):
         """Search should return something sensible."""
         r = self.api.extensions.search_extension(with_usage_count=True)
-        self.assertTrue(r[0].usage_count >= 0)
+        self.assertTrue(r[0].usage_count is not None)
 
     def test_retrieve_extension(self):
         """Retrieve should return a proper Extension."""


### PR DESCRIPTION
When the usageCount is 0, it is returned as `<usageCount/>` instead of
`<usageCount>0</usageCount>`. Apparently this does somehow on python 2, but on 3
it fails.
