### PR TITLE
Fix name string representation

### DIFF
--- a/openprovider/models.py
+++ b/openprovider/models.py
@@ -112,10 +112,10 @@ class Name(Model):
     """
 
     def __str__(self):
-        if hasattr(self, "prefix"):
-            return " ".join((self.first_name, self.prefix, self.last_name))
+        if getattr(self, "prefix", None):
+            return "%s %s %s" % (self.first_name, self.prefix, self.last_name)
         else:
-            return " ".join((self.first_name, self.last_name))
+            return "%s %s" % (self.first_name, self.last_name)
 
 
 class Domain(Model):


### PR DESCRIPTION
string.join expects strings, not StringElement:

```
openprovider.py/openprovider/models.pyc in __str__(self)
   114     def __str__(self):
   115         if hasattr(self, "prefix"):
--> 116             return " ".join((self.first_name, self.prefix, self.last_name))
   117         else:
   118             return " ".join((self.first_name, self.last_name))

TypeError: sequence item 0: expected string, lxml.objectify.StringElement found
```
