### PR TITLE
Handle error pages without data

### DIFF
--- a/openprovider/api.py
+++ b/openprovider/api.py
@@ -92,7 +92,7 @@ class OpenProvider(object):
             klass = from_code(tree.reply.code)
             desc = tree.reply.desc
             code = tree.reply.code
-            data = tree.reply.data
+            data = getattr(tree.reply, 'data', '')
             raise klass("{0} ({1}) {2}".format(desc, code, data))
 
 


### PR DESCRIPTION
A reply doesn't always have an attribute data. This causes AttributeErrors instead of the intended class, for example with a code 4005 (Maintenance).