### PR TITLE
Allow date to be overridden through the constructor

### DIFF
--- a/openprovider/models.py
+++ b/openprovider/models.py
@@ -161,7 +161,17 @@ class RegistryMessage(Model):
 
     @property
     def date(self):
-        return datetime.datetime.strptime(str(self._obj.date), '%Y-%m-%d %H:%M:%S')
+        date = None
+        try:
+            date = self._attrs['date']
+        except KeyError:
+            if self._obj is not None:
+                try:
+                    date = self._obj['date']
+                except (AttributeError, KeyError):
+                    pass
+
+        return datetime.datetime.strptime(str(date), '%Y-%m-%d %H:%M:%S') if date else None
 
 
 class DomainDetails(Model):


### PR DESCRIPTION
This makes the following possible:

	RegistryMessage(date='2015-01-01 00:00:00')