### PR TITLE
Handle empty models in the string representation

### DIFF
--- a/openprovider/models.py
+++ b/openprovider/models.py
@@ -67,7 +67,7 @@ class Model(object):
         return "<%s.%s: %s>" % (type(self).__module__, type(self).__name__, self)
 
     def __str__(self):
-        return str(lxml.etree.tostring(self._obj))
+        return str(lxml.etree.tostring(self._obj)) if self._obj else 'Empty model'
 
 
 def submodel(klass, key):


### PR DESCRIPTION
This happens when you receive an empty object, such as ```<registryDetails/>```, and then transform it into a RegistryDetails object.