### PR TITLE
Remove requests dependency upper version constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(
     description='An unofficial library for the OpenProvider API',
     long_description=open('README.rst').read(),
     install_requires=[
-        "requests >= 2.3.0, <= 2.5.1",
+        "requests >= 2.3.0",
         "lxml >= 3.3.5",
     ],
     tests_require=[


### PR DESCRIPTION
Removes the undocumented and outdated upper version constraint
for the requests dependency.